### PR TITLE
Suppress language prompt

### DIFF
--- a/markdownpad2/markdownpad2.nuspec
+++ b/markdownpad2/markdownpad2.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>markdownpad2</id>
     <title>MarkdownPad2</title>
-    <version>2.3</version>
+    <version>2.5</version>
     <authors>Evan Wondrasek</authors>
     <owners>Ellen Gummesson</owners>
     <summary>A Markdown editor for Windows</summary>

--- a/markdownpad2/tools/chocolateyInstall.ps1
+++ b/markdownpad2/tools/chocolateyInstall.ps1
@@ -2,7 +2,7 @@ $Package = "MarkdownPad2"
 $PackageParams = @{
   packageName = $Package;  
   fileType = "exe";
-  silentArgs = "/quiet";
+  silentArgs = "/quiet /exenoui";
   url = "http://markdownpad.com/download/markdownpad2-setup.exe";
 } 
 

--- a/markdownpad2/tools/chocolateyInstall.ps1
+++ b/markdownpad2/tools/chocolateyInstall.ps1
@@ -6,10 +6,4 @@ $PackageParams = @{
   url = "http://markdownpad.com/download/markdownpad2-setup.exe";
 } 
 
-Try {
-  Install-ChocolateyPackage @PackageParams
-  Write-ChocolateySuccess $Package
-} Catch {
-  Write-ChocolateyFailure $Package "$($_.Exception.Message)"
-  Throw
-}
+Install-ChocolateyPackage @PackageParams

--- a/markdownpad2/tools/chocolateyInstall.ps1
+++ b/markdownpad2/tools/chocolateyInstall.ps1
@@ -2,7 +2,7 @@
 $PackageParams = @{
   packageName = $Package;  
   fileType = "exe";
-  silentArgs = "/quiet /exenoui";
+  silentArgs = "/exenoui /quiet";
   url = "http://markdownpad.com/download/markdownpad2-setup.exe";
 } 
 

--- a/markdownpad2/tools/chocolateyInstall.ps1
+++ b/markdownpad2/tools/chocolateyInstall.ps1
@@ -1,4 +1,4 @@
-$Package = "MarkdownPad2"
+﻿$Package = "MarkdownPad2"
 $PackageParams = @{
   packageName = $Package;  
   fileType = "exe";


### PR DESCRIPTION
Added `/exenoui` to suppress the language prompt from the executable, leaving `/quiet` to suppress the msi ui.

Updated the version to 2.5 (which is what was being installed anyway).

Added the BOM for `chocolateyInstall.ps1`, as required by Powershell.

Removed the try/catch and use of deprecated `Write-ChocolateySuccess` and `Write-ChocolateyFailure`.
